### PR TITLE
fix: Add Session-Refresh Task-Locking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,18 @@
 			<artifactId>spring-boot-devtools</artifactId>
 		</dependency>		
 		-->
+
+		<dependency>
+			<groupId>net.javacrumbs.shedlock</groupId>
+			<artifactId>shedlock-spring</artifactId>
+			<version>4.33.0</version>
+		</dependency>
+		<dependency>
+			<groupId>net.javacrumbs.shedlock</groupId>
+			<artifactId>shedlock-provider-redis-spring</artifactId>
+			<version>4.33.0</version>
+		</dependency>
+
 	</dependencies>
 
 	<dependencyManagement>

--- a/src/main/java/de/witcom/api/config/AsyncConfig.java
+++ b/src/main/java/de/witcom/api/config/AsyncConfig.java
@@ -1,0 +1,30 @@
+package de.witcom.api.config;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import lombok.extern.log4j.Log4j2;
+
+@Configuration
+@EnableAsync
+@Log4j2
+public class AsyncConfig {
+
+    @Bean(name = "gatewayTaskExecutor")
+    public Executor gatewayTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(6);
+        executor.setMaxPoolSize(6);
+        executor.setQueueCapacity(500);
+        executor.setThreadNamePrefix("gateway-task-");
+        executor.initialize();
+        log.debug(String.format("Configured threadPoolTaskExecutor with pool-size", executor.getPoolSize()));
+        return executor;
+    }
+    
+}

--- a/src/main/java/de/witcom/api/config/RedisConfig.java
+++ b/src/main/java/de/witcom/api/config/RedisConfig.java
@@ -4,17 +4,24 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import lombok.extern.log4j.Log4j2;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.redis.spring.RedisLockProvider;
 
 @Configuration
+@Log4j2
 public class RedisConfig {
 
-    Logger logger = LoggerFactory.getLogger(this.getClass());
+	@Bean
+	public LockProvider lockProvider(RedisConnectionFactory connectionFactory) {
+		return new RedisLockProvider(connectionFactory, "API-GATEWAY");
+	}
     
     @Bean
 	StringRedisTemplate template(RedisConnectionFactory connectionFactory) {
-	    logger.debug("Configuring REDIS");
+	    log.debug("Configuring REDIS");
 		return new StringRedisTemplate(connectionFactory);
 	}
     

--- a/src/main/java/de/witcom/api/service/LockManager.java
+++ b/src/main/java/de/witcom/api/service/LockManager.java
@@ -1,0 +1,43 @@
+package de.witcom.api.service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.Month;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.core.SimpleLock;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class LockManager {
+
+	private final LockProvider lockProvider;
+
+	public Optional<SimpleLock> lock(String lockName,Duration minimumLockDuration){
+
+		LockConfiguration lockConfiguration = new LockConfiguration(Instant.now(),
+			lockName,
+			minimumLockDuration,
+			minimumLockDuration
+		);
+		log.debug(String.format("Trying to lock %s", lockConfiguration.toString()));
+
+		//trying to lock
+		return lockProvider.lock(lockConfiguration); 
+
+	}
+
+	public void unlock(Optional<SimpleLock> lock){
+		lock.ifPresent(mylock -> mylock.unlock());
+	}
+	
+}


### PR DESCRIPTION
Adds locking for session-refreshs to avoid paralell session refresh in multi-instance deployments

Closes: #25