### PR TITLE
feat(filter): Adds CommandSessionToHeaderFilter

### DIFF
--- a/.devcontainer/mockserver-expectations/rmdb.json
+++ b/.devcontainer/mockserver-expectations/rmdb.json
@@ -24,5 +24,17 @@
 				"returnData": []
 			}
 		}
+	},
+	{
+		"httpRequest": {
+			"path": "/soapproxy/somews",
+			"method": "POST",
+			"headers": {
+				"X-COMMAND-SESSION-ID": "a-random-sessionid"
+			}
+		},
+		"httpResponse": {
+			"body": {"status":"OK"}
+		}
 	}
 ]

--- a/README.md
+++ b/README.md
@@ -257,9 +257,42 @@ spring:
          - RewritePath=/rmdb/(?<segment>.*), /axis/$\{segment}
 ```
 
+# Custom Filter - Command-Session-ID-to-Header
+Ein Filter der die aktuell gespeicherte Command-Session-ID (siehe KeycloakCommandFilter) in einen konfigurierbaren Header schreibt
+
+## Beispiel
+
+Hier wird der Filter mit einem Keycloak-filter kombiniert um eine Authentifizierung zu erreichen. 
+
+```yaml
+spring:
+  cloud:
+   gateway:
+    globalcors:
+      cors-configurations:
+        '[/**]':
+         allowedOrigins: "*"          
+    routes:
+      - id: command-soap-proxy
+        uri: ${WS_BASEURL:http://localhost:8080/soap-proxy/axis}
+        predicates:
+         - Path=/cmd-ws/**
+        filters:
+         # Checks OAuth-Token for required role
+         - KeyCloakFilter=requiredRole,rmdb-resource-server:worker
+         # Removes existing Authorization-Header
+         - RemoveRequestHeader=Authorization
+         # Adds Command-Session-Id from Session-Manager to header X-COMMAND-SESSION-ID
+         - name: CommandSessionIdToHeaderFilter
+           args:
+             sessionHeader: X-COMMAND-SESSION-ID        
+         # Some rewriting
+         - RewritePath=/cmd-ws/(?<segment>.*), /$\{segment}
+```
+
 # Custom Filter - Ciena MCP mit Keycloak-Authorisierung
 Ein Filter der jeden Zugriff auf die Ciena MCP mit einem gueltigen MCP eigenen OAuth2 Access-Token versieht.
-Der Filter fuehrt einen Login bei FNT Command durch um eine OAuth2-Token zu erhalten. Dieses Token
+Der Filter fuehrt einen Login bei Ciena MCP durch um eine OAuth2-Token zu erhalten. Dieses Token
 wird in einem REDIS Key-Value-Store abgespeichert, um mehrere Instanzen des API-Gateways laufen lassen zu können.
 
 ## Globale Einstellungen

--- a/src/main/java/de/witcom/api/filter/CommandSessionIdToHeaderFilter.java
+++ b/src/main/java/de/witcom/api/filter/CommandSessionIdToHeaderFilter.java
@@ -1,0 +1,84 @@
+package de.witcom.api.filter;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.cloud.gateway.support.HasRouteId;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+
+import de.witcom.api.command.client.CommandSessionManager;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import reactor.core.publisher.Mono;
+
+@Component
+@Log4j2
+public class CommandSessionIdToHeaderFilter
+		extends AbstractGatewayFilterFactory<CommandSessionIdToHeaderFilter.Config> {
+
+	private final CommandSessionManager sessionManager;
+
+	public CommandSessionIdToHeaderFilter(CommandSessionManager sessionManager){
+		super(Config.class);
+		this.sessionManager = sessionManager;
+	}
+
+	@Override
+	public GatewayFilter apply(Config config) {
+
+		return (exchange, chain) -> {
+			if (config == null || StringUtils.isBlank(config.getSessionHeader())) {
+				log.error("No header-name for command-session-id configured");
+				return this.onError(exchange, HttpStatusCode.valueOf(400),
+						"No header-name for command-session-id configured");
+			}
+
+			String sessionId = sessionManager.getSessionId();
+
+			// if we have a session-id
+			if (StringUtils.isNotBlank(sessionId)) {
+				// add Session-ID to header
+				ServerHttpRequest request = exchange.getRequest().mutate()
+					.header(config.getSessionHeader(), sessionId)
+					.build();
+
+				// log.debug(request.getHeaders().toString());
+				return chain.filter(exchange.mutate().request(request).build()).then(Mono.fromRunnable(() -> {
+					ServerHttpResponse response = exchange.getResponse();
+					//If unauthorized -> refresh session so that the next call will be ok
+					if (response.getStatusCode().equals(HttpStatus.UNAUTHORIZED)) {
+						sessionManager.refreshSession();
+					}
+				}));					
+
+			}
+
+			log.warn("Got no Command-Session-ID - API-Call will fail");
+			return chain.filter(exchange);
+
+		};
+
+	}
+
+	private Mono<Void> onError(ServerWebExchange exchange, HttpStatusCode status, String err) {
+		ServerHttpResponse response = exchange.getResponse();
+		response.setStatusCode(status);
+		response.getHeaders().add("x-error-message", err);
+		return response.setComplete();
+	}
+
+	@Data
+	public static class Config implements HasRouteId {
+
+		private String routeId;
+		private String sessionHeader;
+
+	}
+
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -78,6 +78,26 @@ spring:
         filters:
           - KeyCloakFilter=requiredRole,rmdb-resource-server:i-do-not-exist
 
+      - id: command-session-header
+        uri: http://mockserver:1080/
+        predicates:
+         - Path=/soapproxy/**
+        filters:
+         - name: CommandSessionIdToHeaderFilter
+           args:
+             sessionHeader: X-COMMAND-SESSION-ID
+
+      - id: command-session-header-with-auth
+        uri: http://mockserver:1080/
+        predicates:
+          - Path=/soapproxy-auth/**
+        filters:
+          - KeyCloakFilter=requiredRole,rmdb-resource-server:base-work
+          - RemoveRequestHeader=Authorization
+          - name: CommandSessionIdToHeaderFilter
+            args:
+              sessionHeader: X-COMMAND-SESSION-ID
+          - RewritePath=/soapproxy-auth/(?<segment>.*), /soapproxy/$\{segment}    
 
           #- AddRequestHeader=X-Some-Header, custom-header
           #- CommandFilter

--- a/src/test/java/de/witcom/api/CommandSessionIdToHeaderFilterTest.java
+++ b/src/test/java/de/witcom/api/CommandSessionIdToHeaderFilterTest.java
@@ -1,0 +1,83 @@
+package de.witcom.api;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.ApplicationContext;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import de.witcom.api.KeycloakFilterTest.TokenResponse;
+import de.witcom.api.config.properties.ApplicationProperties;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class CommandSessionIdToHeaderFilterTest {
+
+	@LocalServerPort
+	private int port;
+
+	@Autowired
+	private ApplicationProperties appProperties;
+
+	WebTestClient testclient;
+
+	@Value("${API_GW_OAUTH_TESTCLIENT_CLIENTSECRET}")
+	String testClientClientSecret;
+	@Value("${API_GW_OAUTH_TESTCLIENT_CLIENTID}")
+	String testClientClientId;
+
+	@BeforeEach
+	void setupWebClient(){
+		testclient = WebTestClient.bindToServer().baseUrl("http://localhost:"+port).build();
+	}
+
+	private TokenResponse getAccessToken(){
+
+		assertNotNull(testClientClientId);
+		assertNotNull(testClientClientSecret);
+
+		// get an access token
+		String kcBaseUrl = String.format("%s/realms/%s", appProperties.getKeycloakConfig().getKeycloakServerUrl(),appProperties.getKeycloakConfig().getKeycloakRealmId());
+		WebClient kcClient = WebClient.builder()
+			.baseUrl(kcBaseUrl)
+			.defaultHeaders(header -> header.setBasicAuth(testClientClientId, testClientClientSecret))
+			.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+			.build();
+		TokenResponse token = kcClient.post()
+			.uri("/protocol/openid-connect/token")
+			.body(BodyInserters.fromFormData("grant_type", "client_credentials"))
+			.retrieve()
+			.bodyToMono(TokenResponse.class)
+			.block()
+			;
+		return token;			
+
+	}	
+
+	@Test
+	void testCommandSession2Header(){
+		testclient.post().uri("/soapproxy/somews").exchange().expectStatus().isOk();
+	}
+
+	
+	@Test
+	void testCommandSession2HeaderWithAuth(){
+		TokenResponse token = getAccessToken();
+		testclient.post()
+			.uri("/soapproxy-auth/somews")
+			.headers(header -> header.setBearerAuth(token.getAccessToken()))
+			.exchange()
+			.expectStatus()
+			.isOk();
+	}
+
+
+}


### PR DESCRIPTION
Adds a filter that allows adding the current command-session-id to a configurable header

Closes #31